### PR TITLE
Fix major doc typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@
 //! ## Notes:
 //!
 //! * Bombs do nothing if a thread is already panicking.
-//! * When `#[cfg(debug_assertions)]` is enabled, `DebugDropBomb` is
-//!   an always defused and has a zero size.
+//! * When `#[cfg(debug_assertions)]` is disabled, `DebugDropBomb` is
+//!   always defused and has a zero size.
 use std::borrow::Cow;
 
 #[derive(Debug)]


### PR DESCRIPTION
When `cfg(debug_assertions)` is enabled/true, `DebugDropBomb` is a `RealBomb`. When `cfg(debug_assertions)` is disabled/false, `DebugDropBomb` is a `FakeBomb`.

Given the potential confusion here, it might be better to use "When debug assertions are disabled (e.g. in release mode)" than "When `#[cfg(debug_assertions)]` is disabled", but I stuck with the existing verbiage initially.